### PR TITLE
fix: CORS settings to allow access from GitHub Page updated

### DIFF
--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -1,11 +1,11 @@
-# frozen_string_literal: true
-# Rails.application.config.middleware.insert_before 0, Rack::Cors do
-#   allow do
-#     origins 'http://localhost:3000'
+frozen_string_literal: true
+Rails.application.config.middleware.insert_before 0, Rack::Cors do
+  allow do
+    origins 'https://mskk3215.github.io'
 
-#     resource '*',
-#              headers: :any,
-#              methods: %i[get post put patch delete options head],
-#              credentials: true
-#   end
-# end
+    resource '*',
+             headers: :any,
+             methods: %i[get post put patch delete options head],
+             credentials: true
+  end
+end


### PR DESCRIPTION
githubpagesの認証を受け入れるためにcors設定で許可するように修正しました。