### PR TITLE
fix:fetch_current_user_notifications limit from 10 to 15 updated

### DIFF
--- a/app/controllers/api/v1/sighting_notifications_controller.rb
+++ b/app/controllers/api/v1/sighting_notifications_controller.rb
@@ -63,7 +63,7 @@ class Api::V1::SightingNotificationsController < ApplicationController
                                   .includes(collected_insect: %i[insect park])
                                   .order('collected_insects.taken_date_time DESC')
                                   .page(params[:page])
-                                  .per(10)
+                                  .per(15)
       format_notifications(notifications)
     end
 


### PR DESCRIPTION
fetch_current_user_notificationsメソッドの制限を10→15に変更。