### PR TITLE
feat:mini_magick update from 4.12.0 to 4.13.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -185,7 +185,7 @@ GEM
     mime-types (3.5.2)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2024.0305)
-    mini_magick (4.12.0)
+    mini_magick (4.13.2)
     mini_mime (1.1.5)
     minitest (5.22.3)
     msgpack (1.7.2)


### PR DESCRIPTION
db:seed時に以下のエラーがCLI上に表示される為、mini_magickを4.12.0 に4.13.2アップデートしました。

WARNING: The convert command is deprecated in IMv7, use "magick" instead of "convert" or "magick convert"
